### PR TITLE
Container attribute "tag" for named struct

### DIFF
--- a/dynamodel_derive/src/lib.rs
+++ b/dynamodel_derive/src/lib.rs
@@ -64,8 +64,8 @@ impl TargetStruct {
             .map(|f| f.parsed)
             .collect();
 
-        let into_hashmap = structs::into_hashmap(&self.extra, &fields, &rename_rule);
-
+        let into_hashmap =
+            structs::into_hashmap(ident, &self.tag, &self.extra, &fields, &rename_rule);
         let try_from_hashmap = structs::try_from_hashmap(&fields, &rename_rule);
 
         quote! {
@@ -92,7 +92,6 @@ impl TargetStruct {
         let variants = self.data.take_enum().unwrap();
 
         let into_hashmap = enums::into_hashmap(ident, &self.tag, &variants, &rename_rule);
-
         let try_from_hashmap = enums::try_from_hashmap(&self.tag, &variants, &rename_rule);
 
         quote! {

--- a/dynamodel_tests/tests/structs/attributes/container/mod.rs
+++ b/dynamodel_tests/tests/structs/attributes/container/mod.rs
@@ -2,3 +2,4 @@ use super::*;
 
 mod extra;
 mod rename_all;
+mod tag;

--- a/dynamodel_tests/tests/structs/attributes/container/tag.rs
+++ b/dynamodel_tests/tests/structs/attributes/container/tag.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+#[derive(Dynamodel, Debug, PartialEq, Clone)]
+#[dynamodel(tag = "type")]
+struct Person {
+    first_name: String,
+    last_name: String,
+}
+
+#[test]
+fn test_tagged_struct() {
+    let person = Person {
+        first_name: "Kanji".into(),
+        last_name: "Tanaka".into(),
+    };
+
+    let item: HashMap<String, AttributeValue> = [
+        ("type".to_string(), AttributeValue::S("Person".into())),
+        ("first_name".to_string(), AttributeValue::S("Kanji".into())),
+        ("last_name".to_string(), AttributeValue::S("Tanaka".into())),
+    ]
+    .into();
+
+    let converted: HashMap<String, AttributeValue> = person.clone().into();
+    assert_eq!(converted, item);
+
+    let converted: Person = item.try_into().unwrap();
+    assert_eq!(converted, person);
+}


### PR DESCRIPTION
Set the struct's name as a field with the given key to the HashMap.

```rust
#[derive(Dynamodel)]
#[dynamodel(tag = "type")]
struct Person {
    first_name: String,
    last_name: String,
}

// {
//   "type": AttributeValue::S("Person"),
//   "first_name": AttributeValue::S("..."),
//   "last_name": AttributeValue::S("..."),
// }
```